### PR TITLE
getAccessToken() should get API_ACCESS_TOKEN instead of API_ID

### DIFF
--- a/android-instagram-oauth/src/br/com/dina/oauth/instagram/InstagramSession.java
+++ b/android-instagram-oauth/src/br/com/dina/oauth/instagram/InstagramSession.java
@@ -90,7 +90,7 @@ public class InstagramSession {
 	 * @return Access token
 	 */
 	public String getAccessToken() {
-		return sharedPref.getString(API_ID, null);
+		return sharedPref.getString(API_ACCESS_TOKEN, null);
 	}
 
 }


### PR DESCRIPTION
Obvious bug in InstagramSession class.

p.s. have plans to work more to integrate instagram API? wrappers?
